### PR TITLE
Add Horizon Shift '81

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,5 +1,16 @@
 [
   {
+    "name": "Horizon Shift '81",
+    "collection": false,
+    "additional_info": false,
+    "releaseDate": "20/12/2018",
+    "image": "https://cdn02.nintendo-europe.com/media/images/11_square_images/games_18/nintendo_switch_download_software/SQ_NSwitchDS_HorizonShift81.jpg",
+    "url": "https://www.nintendo.co.uk/Games/Nintendo-Switch-download-software/Horizon-Shift-81-1488223.html",
+    "categories": "Shooter, Action, Arcade",
+    "players": "1",
+    "publisher": "Funbox Media"
+  },
+  {
     "name": "Shmup Collection",
     "collection": false,
     "additional_info": "Wolflame supports tate mode",


### PR DESCRIPTION
I put it on the top, as that seems like where you put the last game as well. I couldn’t figure out any coherent system where to put it otherwise though.

If that’s not right, please let me know (and ideally write in the README or CONTRIBUTING file) in what order one should store the game otherwise – alphabetically, by release date, or what.