### PR TITLE
Add Eigengrau

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,4 +1,17 @@
 [
+  {
+    "name": "Eigengrau",
+    "collection": false,
+    "additional_info": "Supports all 4 orientations and separate settings for game and HUD",
+    "releaseDate": "02/11/2023",
+    "image": "https://fs-prod-cdn.nintendo-europe.com/media/images/11_square_images/games_18/nintendo_switch_download_software/1x1_NSwitchDS_Eigengrau_image500w.jpg",
+    "url": "https://www.nintendo.co.uk/Games/Nintendo-Switch-download-software/Eigengrau-2463187.html",
+    "categories": "Action, Puzzle, Arcade, Shooter",
+    "players": "1-2",
+    "developer": "Martin Mauersics",
+    "publisher": "Martin Mauersics",
+    "instructions": "Settings > Game > HUD Direction"
+   },
    {
     "name": "Annalynn",
     "collection": false,

--- a/games.json
+++ b/games.json
@@ -1009,7 +1009,7 @@
     "url": "https://www.nintendo.co.uk/Games/Nintendo-Switch-download-software/GUNBARICH-for-Nintendo-Switch--1249755.html",
     "categories": "Shooter, Action, Arcade, Puzzle",
     "players": "1",
-    "developer": "Psikyo,
+    "developer": "Psikyo",
     "publisher": "Zerodiv",
     "instructions": "From the Pause Menu - Display Settings > Display Orientation"
   },


### PR DESCRIPTION
Hello, I would like to add the colorful shoot 'em up Eigengrau to the list. It supports all 4 orientations and separate settings for game and HUD.

The pull request also fixes a missing quotation mark which was highlighted in my editor.