### PR TITLE
Add Image Fight (i.e. Irem Collection vol. 1)

### DIFF
--- a/games.json
+++ b/games.json
@@ -13,6 +13,19 @@
     "instructions": ""
   },
   {
+    "name": "Image Fight",
+    "collection": "Irem Collection Volume 1",
+    "additional_info": "Works only for arcate versions. Supports FlipGrip (90°) and inverted (270º) orientation.",
+    "releaseDate": "21/11/2023",
+    "image": "https://www.nintendo.com/eu/media/images/11_square_images/games_18/nintendo_switch_5/1x1_NSwitch_IremCollectionVolume1_image500w.jpg",
+    "url": "https://www.nintendo.com/en-gb/Games/Nintendo-Switch-games/Irem-Collection-Volume-1-2485698.html",
+    "categories": "Shooter, Arcade, Action, Adventure",
+    "players": "1",
+    "developer": "Tozai Games",
+    "publisher": "ININ Games",
+    "instructions": "choose game > Options > Display Orientation: 90"
+  },
+  {
     "name": "Air Duel",
     "collection": "Irem Collection Volume 2",
     "additional_info": "",


### PR DESCRIPTION
This is the only game in the collection that supports TATE mode.

I double-checked who the developer of the port/collection is, that is why it differs from the one on DekuDeals.
(Side-note: it seems odd that the porter is marked as the only developer, since the brilliance of the game is by the original developer – not a problem specific to this game or DoesItFlip, really)

Also, while I don’t own the Irem Collection vol. 2, I suspect the instructions and limitations may be the same.